### PR TITLE
Maintenance: Fix TLD typo

### DIFF
--- a/BLOCKLIST.md
+++ b/BLOCKLIST.md
@@ -44,7 +44,7 @@ You can find more information in our [README.md](https://github.com/F4R4DAY/fara
 | freeatlantis.com                     |
 | freecumextremist.com                 |
 | freefedifollowers.ga                 |
-| freespeech.firedragonstudios.comx    |
+| freespeech.firedragonstudios.com     |
 | freespeechextremist.com              |
 | frennet.link                         |
 | gab.ai                               |


### PR DESCRIPTION
Blocklist contains an `comx` tld which is not a valid tld.